### PR TITLE
Reorganize website to emphasize QCArchive over Infrastructure

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,136 +42,64 @@ paginate = 6
 # navigation
 [menu]
     
-  [[menu.main]]
-  name = "About"
-  URL = "/about"
-  weight = 2
 
   [[menu.main]]
   name = "Get Started"
   URL = "/get_started"
-  weight = 3
+  weight = 1
 
   [[menu.main]]
   name = "Blog"
   URL = "/blog"
-  weight = 4
+  weight = 2
   
 
   [[menu.main]]
-  weight = 8
-  name = "Ecosystem"
+  weight = 3
+  name = "Community"
   hasChildren = true
 
     [[menu.main]]
-    parent = "Ecosystem"
-    name = "Community"
+    parent = "Community"
+    name = "Partners"
     URL = "/community"
     weight = 2
 
     [[menu.main]]
-    parent = "Ecosystem"
+    parent = "Community"
     name = "Join Slack"
     URL = "https://join.slack.com/t/qcdb/shared_invite/enQtNDIzNTQ2OTExODk0LWM3OTgxN2ExYTlkMTlkZjA0OTExZDlmNGRlY2M4NWJlNDlkZGQyYWUxOTJmMzc3M2VlYzZjMjgxMDRkYzFmOTE"
     weight = 5
 
     [[menu.main]]
-    parent = "Ecosystem"
-    name = "QCA Projects"
-    URL = "/projects"
-    weight = 1
-
-    [[menu.main]]
-    parent = "Ecosystem"
+    parent = "Community"
     name = "Use Cases"
     URL = "/usecases"
     weight = 3
 
     [[menu.main]]
-    parent = "Ecosystem"
+    parent = "Community"
     name = "Team"
     URL = "/team"
     weight = 4
 
     [[menu.main]]
-    # parent = "Ecosystem"
+    # parent = "Community"
     # name = "License and Funding"
     # URL = "/privacy"
     # weight = 20
   
 
   [[menu.main]]
-  weight = 9
-  name = "Documentation"
-  hasChildren = true
-
-    [[menu.main]]
-    parent = "Documentation"
-    name = "Examples "
-    URL = "https://docs.qcarchive.molssi.org/"
-
-    [[menu.main]]
-    parent = "Documentation"
-    name = "QCPortal "
-    URL = "https://docs.qcarchive.molssi.org/projects/qcportal/en/latest"
-
-    [[menu.main]]
-    parent = "Documentation"
-    name = "QCFractal "
-    URL = "https://docs.qcarchive.molssi.org/projects/qcfractal/en/latest"
-
-    [[menu.main]]
-    parent = "Documentation"
-    name = "QCEngine "
-    URL = "https://docs.qcarchive.molssi.org/projects/qcengine/en/latest"
-
-    [[menu.main]]
-    parent = "Documentation"
-    name = "QCElemental "
-    URL = "https://docs.qcarchive.molssi.org/projects/qcelemental/en/latest"
-
-  [[menu.main]]
+  name = "QCA Infrastructure"
+  URL = "/projects"
   weight = 10
-  name = "GitHub"
-  hasChildren = true
-
-    [[menu.main]]
-    parent = "GitHub"
-    name = "QCPortal"
-    URL = "https://github.com/MolSSI/QCFractal"
-
-    [[menu.main]]
-    parent = "GitHub"
-    name = "QCFractal"
-    URL = "https://github.com/MolSSI/QCFractal"
-
-    [[menu.main]]
-    parent = "GitHub"
-    name = "QCEngine"
-    URL = "https://github.com/MolSSI/QCEngine"
-
-    [[menu.main]]
-    parent = "GitHub"
-    name = "QCElemental"
-    URL = "https://github.com/MolSSI/QCElemental"
-
-
-  # footer menu
-  [[menu.footer]]
-  name = "About"
-  URL = "/about"
-  weight = 1
 
   [[menu.footer]]
   name = "Get Started"
   URL = "/get_started"
   weight = 2
 
-  [[menu.footer]]
-  name = "Examples"
-  URL = "https://docs.qcarchive.molssi.org/"
-  weight = 3
-  
   [[menu.footer]]
   name = "Contact Us"
   URL = "mailto:qcarchive@molssi.org"

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "QCArchive Community"
+title: "QCArchive Partners"
 date: 2019-02-28T12:35:54+06:00
-pageDescription : "Partners from the greater Computational Molecular Sciences doing awesome things with the QCArchive."
+pageDescription : "Partners from the greater Computational Molecular Science community doing awesome things with the QCArchive."
 ---
 

--- a/data/community.yml
+++ b/data/community.yml
@@ -46,7 +46,7 @@ Driver handles the top level task creation logic and post-compute processing."
     - image: "images/collaborators/QuBeKit-300x127.png"
       name: "QUBEKit: bespoke force field parameters derived from QM"
       designation: "Collaborator"
-      content: "The QUantum mechanical Bespoke toolkit (QUBEKit) is a software
+      content: "The QUantum mechanical BEspoke toolkit (QUBEKit) is a software
 package developed at Newcastle University, UK. QUBEKit automates the derivation
 of bespoke bond, angle, dihedral and non-bonded force field parameters for
 small organic molecules directly from quantum chemistry calculations, which are

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -21,7 +21,7 @@ bannerFeature:
 
   - icon: "tf-ion-erlenmeyer-flask"
     title: "Private Instances"
-    description: "The QCArchive ecosystem is fully open-souce. Spin up your own instance to compute private data and share only with collaborators."
+    description: "The infrastructure behind QCArchive is fully open-souce. Spin up your own instance to compute private data and share only with collaborators."
 
 #Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquam non, recusandae tempore ipsam dignissimos molestias."
 
@@ -29,7 +29,7 @@ bannerFeature:
 # LNN note: "enable : false" does not remove these blocks of "featureX"
 featureOne:
   enable : true
-  image : "images/boxology_centered.png" # Make roughly square
+  image : "images/about/violin_plot.png" # Make roughly square
 #  imageAlt : "images/boxology_overview_nobar.webp"
   title : "A free, community-driven, multi-user quantum chemistry database"
   content : 'The core of this project sets out to answer the fundamental question of "How do we compile, aggregate, query, and share quantum chemistry data to accelerate the understanding of new method performance, fitting of novel force fields, and supporting the incredible data needs of machine learning for computational molecular science?"'
@@ -50,7 +50,7 @@ featureTwo:
 
 # service
 service:
-  enable : true
+  enable : false
   title : "QCArchive Ecosystem"
   description : "The QCArchive Ecosystem provides access at every step of the compute lifecycle, from simple result lookup to computation of proprietary basis sets on your hardware."
   # LNN Note: The logic on this image is find the first, 100% opaque pixel and align to the left of that.
@@ -88,6 +88,7 @@ service:
 # LNN: The "enable" works here
 promoVideo:
   enable : True
+  # TODO(Levi): remove the QC, leaving the black textured background
   bgImage : "images/background/qcablackback.png"
   #bgImageAlt : "images/background/qcablackback.png"
   title : "Watch Our Debut Presentation!"
@@ -113,7 +114,7 @@ testimonial:
 
 # download
 download:
-  enable : true
+  enable : false
   title : "Access QCArchive Now"
   description : "Download QCPortal client to access the database"
   downloadButton :
@@ -124,3 +125,11 @@ download:
     - btnText : "PyPI and pip"
       icon : "tf-ion-ios-cloud-download"
       URL : "https://pypi.org/project/qcportal/#description"
+
+getStarted:
+    enable: true
+    title: "Get Started with QCArchive Now"
+    description: "View data, see examples, and more."
+    btnText: "Get Started!"
+    btnURL: "/get_started"
+

--- a/themes/small-apps-v2/layouts/index.html
+++ b/themes/small-apps-v2/layouts/index.html
@@ -50,7 +50,7 @@
 				<div class="col-md-4 mb-4 text-center">
 					<i class="{{ .icon }} text-primary h1"></i>
 					<h3 class="mt-4 text-capitalize h5 ">{{.title }}</h3>
-					<p class="regular text-muted">{{.description | markdownify }}</p>
+					<p class="regular text-muted" style="text-align: justify;">{{.description | markdownify }}</p>
 				</div>
 				{{ end }}
 			</div>
@@ -239,6 +239,24 @@
 					</li>
 					{{ end }}
 				</ul>
+			</div>
+		</div>
+	</div>
+</section>
+{{ end }}
+
+{{ if .Site.Data.homepage.getStarted.enable }}
+<section class="call-to-action-app section bg-blue">
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-12">
+				{{ with .Site.Data.homepage.getStarted }}
+				<h2>{{ .title }}</h2>
+				<p>{{ .description | safeHTML }}</p>
+				<a href="{{ .btnURL | relURL }}" class="btn btn-rounded-icon">
+					{{ .btnText }}
+				</a>
+				{{ end }}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This PR reorganizes the website per our discussion during the 8/19/19 meeting to minimize the QCA Infrastructure and focus the website on the QCArchive. Concretely:

- The "about" page has been removed. It should be repurposed into a QCA Infrastructure landing page.
- The "Community" page has been renamed "Partners"
- The "Documentation" and "Github" menus have been removed.
- The "Ecosystem" menu has been renamed "Community". This menu now contains "Partners", "Team", "Join Slack", and "Use Cases". I'm unsure about the placement of the last one.
- The QCA Ecosystems item has been made a main menu, and renamed "QCA Infrastructure". 
- On the main page, the "QCA Ecosystem" panel has been removed. The "Download" panel has been changed to a "Get Started" panel. 

This PR does not contain updates to the "Get Started" page which are in PR #31. 

This PR partially addresses issue #27. 