### PR TITLE
Expand the submenu for when the menu becomes collapsible

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -70,7 +70,7 @@ pygmentsStyle = "solarized-dark"
     [[menu.main]]
     parent = "Community"
     name = "Join Slack"
-    URL = "https://join.slack.com/t/qcdb/shared_invite/enQtNDIzNTQ2OTExODk0LWM3OTgxN2ExYTlkMTlkZjA0OTExZDlmNGRlY2M4NWJlNDlkZGQyYWUxOTJmMzc3M2VlYzZjMjgxMDRkYzFmOTE"
+    URL = "https://join.slack.com/t/qcarchive/shared_invite/enQtNDIzNTQ2OTExODk0LTE3MWI0YzBjNzVhNzczNDM0ZTA5MmQ1ODcxYTc0YTA1ZDQ2MTk1NDhlMjhjMmQ0YWYwOGMzYzJkZTM2NDlmOGM"
     weight = 5
 
     [[menu.main]]

--- a/themes/small-apps-v2/assets/scss/_variables.scss
+++ b/themes/small-apps-v2/assets/scss/_variables.scss
@@ -1,6 +1,7 @@
 // Variables
 $body-color: #ffffff;
 $primary-color: #2e7eed;
+$link-color: #046db5;
 $secondary-color: #fff;
 $border-color:#cccccc;
 $primary-font: 'Open Sans', sans-serif;

--- a/themes/small-apps-v2/assets/scss/components/_navigation.scss
+++ b/themes/small-apps-v2/assets/scss/components/_navigation.scss
@@ -1,103 +1,121 @@
 .main-nav{
-	background: $light;
-	.navbar-brand{
-		padding: 0;
-	}
-	.navbar-nav{
-		.nav-item{
-			position: relative;
-			font-family: $primary-font;
-			.nav-link{
-				position: relative;
-				text-align: center;
-				font-size: 13px;
-				text-transform: uppercase;
-				font-weight: 600;
-				color: $dark;
-				padding-left: 20px;
-				padding-right: 20px;
-				line-height: 45px;
+  background: $light;
+  .navbar-brand{
+	padding: 0;
+  }
+  .navbar-nav{
+	.nav-item{
+	  position: relative;
+	  font-family: $primary-font;
+	  .nav-link{
+		position: relative;
+		text-align: center;
+		font-size: 13px;
+		text-transform: uppercase;
+		font-weight: 600;
+		color: $dark;
+		padding-left: 20px;
+		padding-right: 20px;
+		line-height: 45px;
+	  }
+	  &.active{
+		.nav-link{
+		  color: $primary-color;
+		  &:before{
+			@include tablet {
+			  content: none;
 			}
-			&.active{
-				.nav-link{
-					color: $primary-color;
-					&:before{
-						@include tablet {
-							content: none;
-						}
-						content: '';
-						background: $primary-color;
-						width: 100%;
-						height: 4px;
-						position: absolute;
-						top: 0;
-						left: 0;
-					}
-				}
-			}
+			content: '';
+			background: $primary-color;
+			width: 100%;
+			height: 4px;
+			position: absolute;
+			top: 0;
+			left: 0;
+		  }
 		}
+	  }
 	}
-	.dropdown-slide {
-	  position: static;
-	  .open>a, .open>a:focus, .open>a:hover {
-	    background: transparent;
-	  }
-	  &.full-width {
-	    .dropdown-menu {
-	      left:0!important;
-	      right:0!important;
-	    }
-	  }
-	  &:hover .dropdown-menu {
-	    display:none;
-	    opacity: 1;
-	    display: block;
-	    transform: translate(0px ,0px);
-	    opacity: 1;
-	    visibility: visible;
-	    color: #777;
-	    transform: translateY(0px);
-	    @include tablet {
-    	    transform: none;
-		    left: auto;
-		    position: relative;
-		    text-align: center;
-	    }
-	  }
+  }
+  .dropdown-slide {
+	position: static;
+	.open>a, .open>a:focus, .open>a:hover {
+	  background: transparent;
+	}
+
+	&.full-width {
 	  .dropdown-menu {
-	  	.dropdown-item{
-	  		font-size: 13px;
-  		    padding: 4px 10px;
-  		    transition: .3s ease;
-  		    &:hover{
-  		    	transform: translate3d(5px,0,0);
-  		    	background: $light;
-  		    	color: $primary-color;
-  		    }
-	  	}
-	  	margin-top: 0;
-	    border-radius:0;
-	    opacity: 1;
-	    visibility: visible;
-	    position: absolute;
-	    padding: 5px 15px;
-	    border: 1px solid #ebebeb;
-	    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-	    transition:.3s all;
-	    position: absolute;
-	    display: block;
-	    visibility: hidden;
-	    opacity: 0;
-	    transform: translateY(30px);
-	    transition: visibility 0.2s, opacity 0.2s, transform 500ms cubic-bezier(0.43, 0.26, 0.11, 0.99);
-	    @include mobile {
-	      transform:none;
-	    }
+		left:0!important;
+		right:0!important;
 	  }
 	}
+	&:hover .dropdown-menu {
+	  opacity: 1;
+	  display: block;
+	  transform: translate(0px ,0px);
+	  opacity: 1;
+	  visibility: visible;
+	  color: #777;
+	  transform: translateY(0px);
+	}
+	.dropdown-menu {
+	  .dropdown-item {
+		font-size: 13px;
+		padding: 4px 10px;
+		transition: .3s ease;
+		&:hover{
+		  transform: translate3d(5px,0,0);
+		  background: $light;
+		  color: $link-color;
+
+		  @include desktop {
+			transform: translate3d(0,0,0);
+		  }
+		}
+	  }
+	  margin-top: 0;
+	  border-radius:0;
+	  opacity: 1;
+	  position: absolute;
+	  padding: 5px 15px;
+	  border: 1px solid #ebebeb;
+	  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+	  transition:.3s all;
+	  position: absolute;
+	  display: block;
+	  visibility: hidden;
+	  opacity: 0;
+	  transform: translateY(30px);
+	  transition: visibility 0.2s, opacity 0.2s, transform 500ms cubic-bezier(0.43, 0.26, 0.11, 0.99);
+	  @include mobile {
+		transform:none;
+	  }
+
+	  @include desktop {
+		position: static;
+		visibility: visible;
+		border: 0;
+		opacity: 1;
+		transform: none;
+		box-shadow: none;
+		text-align: center;
+		padding-top: 0;
+	  }
+	}
+
+	@include desktop {
+	  .nav-link {
+		padding-bottom: 0;
+
+		& > span {
+		  display: none;
+		}
+	  }
+	}
+  }
 }
 
 // bootstrap override
 .navbar-toggler:focus, .navbar-toggler:hover{
-	outline: none;
+  outline: none;
 }


### PR DESCRIPTION
When the main nav menu switches to mobile/collapsible mode (> Desktop size) position the submenu inline with the top-level items and display it.
Adjust some padding
Add link color variable and use the color for the submenu item mouse over state
Remove dropdown indicator on the mobile mode